### PR TITLE
Fix triangle count validation in WriteSTLBinary function

### DIFF
--- a/stl/stl.go
+++ b/stl/stl.go
@@ -141,7 +141,7 @@ func WriteSTLBinary(filename string, triangles []types.Triangle) error {
 	}
 
 	triangleCount := len(triangles)
-	if triangleCount < 0 || triangleCount > math.MaxUint32 {
+	if triangleCount < 0 {
 		return errors.New(errors.ValidationError, "invalid number of triangles for STL format", nil)
 	}
 	if err := writeTriangleCount(writer, uint32(triangleCount)); err != nil {


### PR DESCRIPTION
Correct the validation logic for the triangle count to ensure it does not allow negative values.