### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # This repository is maintained by:
 
-* @chrisreddington @leereilly @martinwoodward
+* @chrisreddington @leereilly


### PR DESCRIPTION
This pull request includes a small change to the `CODEOWNERS` file. The change removes `@martinwoodward` from the list of repository maintainers.