### PR TITLE
Refactor isPixelActive into calculatePixelIntensity

### DIFF
--- a/stl/geometry/text.go
+++ b/stl/geometry/text.go
@@ -135,7 +135,8 @@ func renderText(config textRenderConfig) ([]types.Triangle, error) {
 
 	for y := 0; y < config.contextHeight; y++ {
 		for x := 0; x < config.contextWidth; x++ {
-			if isPixelActive(dc, x, y) {
+			intensity := isPixelActive(dc, x, y)
+			if intensity > 0 {
 				xPos := config.startX + float64(x)*config.voxelScale/8
 				zPos := config.startZ - float64(y)*config.voxelScale/8
 
@@ -144,7 +145,7 @@ func renderText(config textRenderConfig) ([]types.Triangle, error) {
 					config.startY,
 					zPos,
 					config.voxelScale/2,
-					config.depth,
+					config.depth*intensity,
 					config.voxelScale/2,
 				)
 				if err != nil {
@@ -216,7 +217,8 @@ func renderImage(config imageRenderConfig) ([]types.Triangle, error) {
 	for y := height - 1; y >= 0; y-- {
 		for x := 0; x < width; x++ {
 			r, _, _, a := img.At(x, y).RGBA()
-			if a > 32768 && r > 32768 {
+			intensity := float64(r) / 65535.0
+			if a > 32768 && intensity > 0 {
 				xPos := config.startX + float64(x)*config.voxelScale*scale
 				zPos := config.startZ + float64(height-1-y)*config.voxelScale*scale
 
@@ -225,7 +227,7 @@ func renderImage(config imageRenderConfig) ([]types.Triangle, error) {
 					config.startY,
 					zPos,
 					config.voxelScale*scale,
-					config.depth,
+					config.depth*intensity,
 					config.voxelScale*scale,
 				)
 
@@ -242,7 +244,7 @@ func renderImage(config imageRenderConfig) ([]types.Triangle, error) {
 }
 
 // isPixelActive checks if a pixel is active (white) in the given context.
-func isPixelActive(dc *gg.Context, x, y int) bool {
+func isPixelActive(dc *gg.Context, x, y int) float64 {
 	r, _, _, _ := dc.Image().At(x, y).RGBA()
-	return r > 32768
+	return float64(r) / 65535.0
 }

--- a/stl/geometry/text.go
+++ b/stl/geometry/text.go
@@ -135,7 +135,7 @@ func renderText(config textRenderConfig) ([]types.Triangle, error) {
 
 	for y := 0; y < config.contextHeight; y++ {
 		for x := 0; x < config.contextWidth; x++ {
-			intensity := isPixelActive(dc, x, y)
+			intensity := calculatePixelIntensity(dc, x, y)
 			if intensity > 0 {
 				xPos := config.startX + float64(x)*config.voxelScale/8
 				zPos := config.startZ - float64(y)*config.voxelScale/8
@@ -243,8 +243,10 @@ func renderImage(config imageRenderConfig) ([]types.Triangle, error) {
 	return triangles, nil
 }
 
-// isPixelActive checks if a pixel is active (white) in the given context.
-func isPixelActive(dc *gg.Context, x, y int) float64 {
+// calculatePixelIntensity returns the intensity of a pixel at the given coordinates
+// as a float64 value between 0.0 (black) and 1.0 (white).
+func calculatePixelIntensity(dc *gg.Context, x, y int) float64 {
 	r, _, _, _ := dc.Image().At(x, y).RGBA()
-	return float64(r) / 65535.0
+	intensity := float64(r) / 65535.0
+	return intensity
 }

--- a/stl/geometry/text_test.go
+++ b/stl/geometry/text_test.go
@@ -117,7 +117,7 @@ func TestIsPixelActive(t *testing.T) {
 		dc.SetRGB(1, 1, 1) // White
 		dc.Clear()
 
-		if !isPixelActive(dc, 0, 0) {
+		if isPixelActive(dc, 0, 0) <= 0 {
 			t.Error("Expected white pixel to be active")
 		}
 	})
@@ -127,8 +127,19 @@ func TestIsPixelActive(t *testing.T) {
 		dc.SetRGB(0, 0, 0) // Black
 		dc.Clear()
 
-		if isPixelActive(dc, 0, 0) {
+		if isPixelActive(dc, 0, 0) > 0 {
 			t.Error("Expected black pixel to be inactive")
+		}
+	})
+
+	t.Run("verify grayscale pixel detection", func(t *testing.T) {
+		dc := gg.NewContext(1, 1)
+		dc.SetRGB(0.5, 0.5, 0.5) // Gray
+		dc.Clear()
+
+		intensity := isPixelActive(dc, 0, 0)
+		if intensity <= 0 || intensity >= 1 {
+			t.Errorf("Expected grayscale pixel to have intensity between 0 and 1, got %f", intensity)
 		}
 	})
 }


### PR DESCRIPTION
This pull request aims to address #13. It includes changes to improve the rendering of text and images by using pixel intensity instead of a binary pixel check.

In addition to the implementation change, there are tweaks to the tests, with the introduction of a new gradient circle test to check that the intensity calculations are working as expected, and not providing a binary 0 or 1.