### PR TITLE
Update year formatting to YYYY-YY format in output

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,8 @@ func formatYearRange(startYear, endYear int) string {
 	if startYear == endYear {
 		return fmt.Sprintf("%d", startYear)
 	}
-	return fmt.Sprintf("%02d-%02d", startYear%100, endYear%100)
+	// Use YYYY-YY format for multi-year ranges
+	return fmt.Sprintf("%04d-%02d", startYear, endYear%100)
 }
 
 // generateOutputFilename creates a consistent filename for the STL output

--- a/main_test.go
+++ b/main_test.go
@@ -39,7 +39,7 @@ func TestFormatYearRange(t *testing.T) {
 			name:      "different years",
 			startYear: 2020,
 			endYear:   2024,
-			want:      "20-24",
+			want:      "2020-24",
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestGenerateOutputFilename(t *testing.T) {
 			user:      "testuser",
 			startYear: 2020,
 			endYear:   2024,
-			want:      "testuser-20-24-github-skyline.stl",
+			want:      "testuser-2020-24-github-skyline.stl",
 		},
 	}
 


### PR DESCRIPTION
Fixes #42

Change the year formatting in output to use the YYYY-YY format to align with version in render. Update tests to reflect the new formatting.