### PR TITLE
fix: low resolution username and year

### DIFF
--- a/stl/geometry/text.go
+++ b/stl/geometry/text.go
@@ -35,10 +35,12 @@ const (
 	logoLeftOffset = 0.03 // Percent
 	
 	usernameFontSize     = 120.0
+	usernameJustification= "left" // "left", "center", "right"
 	usernameLeftOffset   = 0.1 // Percent
 	
 	yearFontSize         = 100.0
-	yearLeftOffset       = 0.85 // Percent
+	yearJustification	= "right" // "left", "center", "right"
+	yearLeftOffset       = 0.97 // Percent
 )
 
 // Create3DText generates 3D text geometry for the username and year.
@@ -49,6 +51,7 @@ func Create3DText(username string, year string, baseWidth float64, baseHeight fl
 
 	usernameTriangles, err := renderText(
 		username,
+		usernameJustification,
 		usernameLeftOffset,
 		usernameFontSize,
 		baseWidth,
@@ -60,6 +63,7 @@ func Create3DText(username string, year string, baseWidth float64, baseHeight fl
 
 	yearTriangles, err := renderText(
 		year,
+		yearJustification,
 		yearLeftOffset,
 		yearFontSize,
 		baseWidth,
@@ -83,7 +87,7 @@ func Create3DText(username string, year string, baseWidth float64, baseHeight fl
 //
 // Returns:
 //   ([]types.Triangle, error): A slice of triangles representing text.
-func renderText(text string, leftOffsetPercent float64, fontSize float64, baseWidth float64, baseHeight float64) ([]types.Triangle, error) {
+func renderText(text string, justification string, leftOffsetPercent float64, fontSize float64, baseWidth float64, baseHeight float64) ([]types.Triangle, error) {
 	// Create a rendering context for the face of the skyline
 	faceWidthRes := baseWidthVoxelResolution
 	faceHeightRes := int(float64(faceWidthRes) * baseHeight/baseWidth)
@@ -110,12 +114,22 @@ func renderText(text string, leftOffsetPercent float64, fontSize float64, baseWi
 	// Draw text on image at desired location
 	var triangles []types.Triangle
 
-	// Draw pixelated text in image at desired location
+	// Convert justification to a number
+	var justificationPercent float64
+	switch justification {
+	case "center":
+		justificationPercent = 0.5
+	case "right":
+		justificationPercent = 1.0
+	default:
+		justificationPercent = 0.0
+	}
+
 	dc.DrawStringAnchored(
 		text,
 		float64(faceWidthRes)*leftOffsetPercent, // Offset from right
 		float64(faceHeightRes)*0.5, // Offset from top
-		0.0, // Left aligned
+		justificationPercent, // Justification (0.0=left, 0.5=center, 1.0=right)
 		0.5, // Vertically aligned
 	)
 

--- a/stl/geometry/text.go
+++ b/stl/geometry/text.go
@@ -10,37 +10,21 @@ import (
 	"github.com/github/gh-skyline/types"
 )
 
-// Common configuration for rendered elements
-type renderConfig struct {
-	startX     float64
-	startY     float64
-	startZ     float64
-	voxelScale float64
-	depth      float64
-}
-
-// ImageConfig holds parameters for image rendering
-type imageRenderConfig struct {
-	renderConfig
-	imagePath string
-	height    float64
-}
-
 const (
 	baseWidthVoxelResolution = 2000 // Number of voxels across the skyline face
-	voxelDepth      = 1.0 // Distance to come out of face
+	voxelDepth               = 1.0  // Distance to come out of face
 
-	logoScale      = 0.4 // Percent
+	logoScale      = 0.4  // Percent
 	logoTopOffset  = 0.15 // Percent
 	logoLeftOffset = 0.03 // Percent
-	
-	usernameFontSize     = 120.0
-	usernameJustification= "left" // "left", "center", "right"
-	usernameLeftOffset   = 0.1 // Percent
-	
-	yearFontSize         = 100.0
-	yearJustification	= "right" // "left", "center", "right"
-	yearLeftOffset       = 0.97 // Percent
+
+	usernameFontSize      = 120.0
+	usernameJustification = "left" // "left", "center", "right"
+	usernameLeftOffset    = 0.1    // Percent
+
+	yearFontSize      = 100.0
+	yearJustification = "right" // "left", "center", "right"
+	yearLeftOffset    = 0.97    // Percent
 )
 
 // Create3DText generates 3D text geometry for the username and year.
@@ -81,17 +65,19 @@ func Create3DText(username string, year string, baseWidth float64, baseHeight fl
 // It returns an array of types.Triangle.
 //
 // Parameters:
-//   text (string): The text to be displayed on the skyline's front face.
-//   leftOffsetPercent (float64): The percentage distance from the left to start displaying the text.
-//   fontSize (float64): How large to make the text. Note: It scales with the baseWidthVoxelResolution.
+//
+//	text (string): The text to be displayed on the skyline's front face.
+//	leftOffsetPercent (float64): The percentage distance from the left to start displaying the text.
+//	fontSize (float64): How large to make the text. Note: It scales with the baseWidthVoxelResolution.
 //
 // Returns:
-//   ([]types.Triangle, error): A slice of triangles representing text.
+//
+//	([]types.Triangle, error): A slice of triangles representing text.
 func renderText(text string, justification string, leftOffsetPercent float64, fontSize float64, baseWidth float64, baseHeight float64) ([]types.Triangle, error) {
 	// Create a rendering context for the face of the skyline
 	faceWidthRes := baseWidthVoxelResolution
-	faceHeightRes := int(float64(faceWidthRes) * baseHeight/baseWidth)
-	
+	faceHeightRes := int(float64(faceWidthRes) * baseHeight / baseWidth)
+
 	// Create image representing the skyline face
 	dc := gg.NewContext(faceWidthRes, faceHeightRes)
 	dc.SetRGB(0, 0, 0)
@@ -128,9 +114,9 @@ func renderText(text string, justification string, leftOffsetPercent float64, fo
 	dc.DrawStringAnchored(
 		text,
 		float64(faceWidthRes)*leftOffsetPercent, // Offset from right
-		float64(faceHeightRes)*0.5, // Offset from top
-		justificationPercent, // Justification (0.0=left, 0.5=center, 1.0=right)
-		0.5, // Vertically aligned
+		float64(faceHeightRes)*0.5,              // Offset from top
+		justificationPercent,                    // Justification (0.0=left, 0.5=center, 1.0=right)
+		0.5,                                     // Vertically aligned
 	)
 
 	// Convert context image pixels into voxels
@@ -163,35 +149,37 @@ func renderText(text string, justification string, leftOffsetPercent float64, fo
 // It returns a slice of types.Triangle representing the cube and an error if the cube creation fails.
 //
 // Parameters:
-//   x (float64): The x-coordinate on the skyline face (left to right).
-//   y (float64): The y-coordinate on the skyline face (top to bottom).
-//   height (float64): Distance coming out of the face.
+//
+//	x (float64): The x-coordinate on the skyline face (left to right).
+//	y (float64): The y-coordinate on the skyline face (top to bottom).
+//	height (float64): Distance coming out of the face.
 //
 // Returns:
-//   ([]types.Triangle, error): A slice of triangles representing the cube and an error if any.
+//
+//	([]types.Triangle, error): A slice of triangles representing the cube and an error if any.
 func createVoxelOnFace(x float64, y float64, height float64, baseWidth float64, baseHeight float64) ([]types.Triangle, error) {
 	// Mapping resolution
 	xResolution := float64(baseWidthVoxelResolution)
 	yResolution := xResolution * baseHeight / baseWidth
 
 	// Pixel size
-	voxelSize := 1.0;
+	voxelSize := 1.0
 
 	// Scale coordinate to face resolution
 	x = (x / xResolution) * baseWidth
 	y = (y / yResolution) * baseHeight
-	voxelSizeX := (voxelSize / xResolution) * baseWidth;
-	voxelSizeY := (voxelSize / yResolution) * baseHeight;
+	voxelSizeX := (voxelSize / xResolution) * baseWidth
+	voxelSizeY := (voxelSize / yResolution) * baseHeight
 
 	cube, err := CreateCube(
 		// Location (from top left corner of skyline face)
-		x, // x - Left to right
-		-height, // y - Negative comes out of face. Positive goes into face.
-		-voxelSizeY - y, // z - Bottom to top
-		
+		x,             // x - Left to right
+		-height,       // y - Negative comes out of face. Positive goes into face.
+		-voxelSizeY-y, // z - Bottom to top
+
 		// Size
 		voxelSizeX, // x length - left to right from specified point
-		height, // thickness - distance coming out of face
+		height,     // thickness - distance coming out of face
 		voxelSizeY, // y length - bottom to top from specified point
 	)
 
@@ -220,13 +208,12 @@ func GenerateImageGeometry(baseWidth float64, baseHeight float64) ([]types.Trian
 }
 
 // renderImage generates 3D geometry for the given image configuration.
-// func renderImage(config imageRenderConfig) ([]types.Triangle, error) {
 func renderImage(filePath string, scale float64, height float64, leftOffsetPercent float64, topOffsetPercent float64, baseWidth float64, baseHeight float64) ([]types.Triangle, error) {
 
 	// Get voxel resolution of base face
 	faceWidthRes := baseWidthVoxelResolution
-	faceHeightRes := int(float64(faceWidthRes) * baseHeight/baseWidth)
-	
+	faceHeightRes := int(float64(faceWidthRes) * baseHeight / baseWidth)
+
 	// Load image from file
 	reader, err := os.Open(filePath)
 	if err != nil {
@@ -260,8 +247,8 @@ func renderImage(filePath string, scale float64, height float64, leftOffsetPerce
 			if a > 32768 && r > 32768 {
 
 				voxel, err := createVoxelOnFace(
-					(leftOffsetPercent * float64(faceWidthRes)) + float64(x)*logoScale,
-					(topOffsetPercent * float64(faceHeightRes)) + float64(y)*logoScale,
+					(leftOffsetPercent*float64(faceWidthRes))+float64(x)*scale,
+					(topOffsetPercent*float64(faceHeightRes))+float64(y)*scale,
 					height,
 					baseWidth,
 					baseHeight,

--- a/stl/geometry/text_test.go
+++ b/stl/geometry/text_test.go
@@ -13,10 +13,6 @@ import (
 
 // TestCreate3DText verifies text geometry generation functionality.
 func TestCreate3DText(t *testing.T) {
-	// Skip tests if fonts are not available
-	if _, err := os.Stat(FallbackFont); err != nil {
-		t.Skip("Skipping text tests as font files are not available")
-	}
 
 	t.Run("verify basic text mesh generation", func(t *testing.T) {
 		triangles, err := Create3DText("test", "2023", 100.0, 5.0)
@@ -63,47 +59,37 @@ func TestCreate3DText(t *testing.T) {
 
 // TestRenderText verifies internal text rendering functionality
 func TestRenderText(t *testing.T) {
-	// Skip if fonts not available
-	if _, err := os.Stat(FallbackFont); err != nil {
-		t.Skip("Skipping text tests as font files are not available")
-	}
+	t.Run("verify text renders", func(t *testing.T) {
+		triangles, err := renderText(
+			"Mona", // text
+			"left", // justification
+			0.1, // leftOffsetPercent
+			10.0, // fontSize
+			200.0, // baseWidth
+			10.0, // baseHeight
+		)
 
-	t.Run("verify text config validation", func(t *testing.T) {
-		invalidConfig := textRenderConfig{
-			renderConfig: renderConfig{
-				startX:     0,
-				startY:     0,
-				startZ:     0,
-				voxelScale: 0, // Invalid scale
-				depth:      1,
-			},
-			text:          "test",
-			contextWidth:  100,
-			contextHeight: 100,
-			fontSize:      10,
+		if err != nil {
+			t.Fatalf("renderText failed: %v", err)
 		}
-		_, err := renderText(invalidConfig)
-		if err == nil {
-			t.Error("Expected error for invalid text config")
+		if len(triangles) == 0 {
+			t.Error("Expected non-zero triangles for rendered text")
 		}
 	})
 }
 
 // TestRenderImage verifies internal image rendering functionality
 func TestRenderImage(t *testing.T) {
-	t.Run("verify invalid image path", func(t *testing.T) {
-		config := imageRenderConfig{
-			renderConfig: renderConfig{
-				startX:     0,
-				startY:     0,
-				startZ:     0,
-				voxelScale: 1,
-				depth:      1,
-			},
-			imagePath: "nonexistent.png",
-			height:    10,
-		}
-		_, err := renderImage(config)
+	t.Run("verify invalid image", func(t *testing.T) {
+		_, err := renderImage(
+			"nonexistent.png", // filePath
+			0.5, // scale
+			100.0, // height
+			0.1, // leftOffsetPercent
+			0.1, // topOffsetPercent
+			200.0, // baseWidth
+			10.0, // baseHeight
+		)
 		if err == nil {
 			t.Error("Expected error for invalid image path")
 		}

--- a/stl/geometry/text_test.go
+++ b/stl/geometry/text_test.go
@@ -63,10 +63,10 @@ func TestRenderText(t *testing.T) {
 		triangles, err := renderText(
 			"Mona", // text
 			"left", // justification
-			0.1, // leftOffsetPercent
-			10.0, // fontSize
-			200.0, // baseWidth
-			10.0, // baseHeight
+			0.1,    // leftOffsetPercent
+			10.0,   // fontSize
+			200.0,  // baseWidth
+			10.0,   // baseHeight
 		)
 
 		if err != nil {
@@ -83,12 +83,12 @@ func TestRenderImage(t *testing.T) {
 	t.Run("verify invalid image", func(t *testing.T) {
 		_, err := renderImage(
 			"nonexistent.png", // filePath
-			0.5, // scale
-			100.0, // height
-			0.1, // leftOffsetPercent
-			0.1, // topOffsetPercent
-			200.0, // baseWidth
-			10.0, // baseHeight
+			0.5,               // scale
+			100.0,             // height
+			0.1,               // leftOffsetPercent
+			0.1,               // topOffsetPercent
+			200.0,             // baseWidth
+			10.0,              // baseHeight
 		)
 		if err == nil {
 			t.Error("Expected error for invalid image path")


### PR DESCRIPTION
This pull request fixes the issue of low resolution username and year.

It includes significant changes to the text and image rendering functionalities in the `stl/geometry/text.go` file. The changes involve refactoring the code to simplify and enhance the rendering process, removing redundant configurations, and introducing an adjustable resolution parameter `baseWidthVoxelResolution`.

Refactoring and simplification:

* Removed the `textRenderConfig` and `imageRenderConfig` structs and their associated configurations, simplifying the parameters for text and image rendering functions.
* Refactored the `renderText` function to align text on the skyline face using justification and offset percentages instead of fixed context dimensions. Added detailed comments to explain the parameters and return values.
* Introduced a new helper function `createVoxelOnFace` to create voxels on the skyline base's face, improving modularity and readability.

### Before
<img width="500" alt="image" src="https://github.com/user-attachments/assets/01893f45-05e1-4b8e-82cd-6c73a609db7c" />

### After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4066614b-140f-44fa-9a60-d450ad9e219a" />

