### PR TITLE
Year to date support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,8 @@ var (
 	web        bool
 	artOnly    bool
 	output     string
-	yearToDate bool   // renamed from ytd
-	until      string // renamed from ytdEnd
+	yearToDate bool
+	until      string
 )
 
 // rootCmd is the root command for the GitHub Skyline CLI tool.

--- a/cmd/skyline/skyline_test.go
+++ b/cmd/skyline/skyline_test.go
@@ -72,7 +72,7 @@ func TestGenerateSkyline(t *testing.T) {
 				return github.NewClient(tt.mockClient), nil
 			}
 
-			err := GenerateSkyline(tt.startYear, tt.endYear, tt.targetUser, tt.full, "", false)
+			err := GenerateSkyline(tt.startYear, tt.endYear, tt.targetUser, tt.full, "", false, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateSkyline() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/testutil/mocks/github.go
+++ b/internal/testutil/mocks/github.go
@@ -49,6 +49,23 @@ func (m *MockGitHubClient) FetchContributions(username string, year int) (*types
 	return fixtures.GenerateContributionsResponse(username, year), nil
 }
 
+// FetchContributionsForDateRange implements GitHubClientInterface
+func (m *MockGitHubClient) FetchContributionsForDateRange(username string, from, to time.Time) (*types.ContributionsResponse, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if username == "" {
+		return nil, fmt.Errorf("username cannot be empty")
+	}
+	if from.After(to) {
+		return nil, fmt.Errorf("start date must be before end date")
+	}
+	if m.MockData != nil {
+		return m.MockData, nil
+	}
+	return fixtures.GenerateContributionsResponse(username, from.Year()), nil
+}
+
 // Do implements APIClient
 func (m *MockGitHubClient) Do(_ string, _ map[string]interface{}, response interface{}) error {
 	if m.Err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -62,15 +62,31 @@ func FormatYearRange(startYear, endYear int) string {
 	return fmt.Sprintf("%04d-%02d", startYear, endYear%100)
 }
 
-// GenerateOutputFilename creates a consistent filename for the STL output
-func GenerateOutputFilename(user string, startYear, endYear int, output string) string {
-	if output != "" {
-		// Ensure the filename ends with .stl
-		if !strings.HasSuffix(strings.ToLower(output), ".stl") {
-			return output + ".stl"
-		}
-		return output
+// GenerateOutputFilename creates a filename for the STL output based on the user and year range.
+func GenerateOutputFilename(username string, startYear, endYear int, customPath string, ytdEnd string) string {
+	if customPath != "" {
+		return customPath
 	}
-	yearStr := FormatYearRange(startYear, endYear)
-	return fmt.Sprintf(outputFileFormat, user, yearStr)
+
+	now := time.Now()
+	isYTD := endYear == now.Year() && startYear == now.AddDate(0, -12, 0).Year()
+
+	var filename string
+	switch {
+	case isYTD:
+		// For YTD mode, use a date range format
+		endDate := now
+		if ytdEnd != "" {
+			if parsed, err := time.Parse("2006-01-02", ytdEnd); err == nil {
+				endDate = parsed
+			}
+		}
+		filename = fmt.Sprintf("%s-contributions-ytd-%s.stl", username, endDate.Format("2006-01-02"))
+	case startYear == endYear:
+		filename = fmt.Sprintf("%s-contributions-%d.stl", username, startYear)
+	default:
+		filename = fmt.Sprintf("%s-contributions-%d-%d.stl", username, startYear, endYear)
+	}
+
+	return filename
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -166,7 +166,7 @@ func TestGenerateOutputFilename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateOutputFilename(tt.user, tt.startYear, tt.endYear, tt.output)
+			got := GenerateOutputFilename(tt.user, tt.startYear, tt.endYear, tt.output, "")
 			if got != tt.want {
 				t.Errorf("generateOutputFilename() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Another potential proposal for to address https://github.com/github/gh-skyline/issues/33

With this change you can now do.

% ./gh-skyline --user nandosobral03 --year-to-date
% ./gh-skyline --user nandosobral03 --year-to-date --until 2025-01-01

And with this generate the skyline for commits from the past year (by default matching with what is shown by default on your github profile)

I'm not 100% sure about the CLI UX but wrote this mainly as something I wanted to use and to propose an alternative to the period based solution. It does have to it's favor that we don't need to worry about varying widths since it's the same number of weeks as the yearly solution

<img width="571" alt="image" src="https://github.com/user-attachments/assets/b1cf9a1b-3de4-4599-99ab-588d5abc30b7" />

![image](https://github.com/user-attachments/assets/317fb2af-a615-4a88-ba96-aa4e77ec1368)
