### PR TITLE
Add label for model

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 var (
 	yearRange string
 	user      string
+	label     string
 	full      bool
 	debug     bool
 	web       bool
@@ -69,6 +70,7 @@ func initFlags() {
 	flags := rootCmd.Flags()
 	flags.StringVarP(&yearRange, "year", "y", fmt.Sprintf("%d", time.Now().Year()), "Year or year range (e.g., 2024 or 2014-2024)")
 	flags.StringVarP(&user, "user", "u", "", "GitHub username (optional, defaults to authenticated user)")
+	flags.StringVarP(&label, "label", "l", "", "Label for the generated model (optional, defaults to username)")
 	flags.BoolVarP(&full, "full", "f", false, "Generate contribution graph from join year to current year")
 	flags.BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 	flags.BoolVarP(&web, "web", "w", false, "Open GitHub profile (authenticated or specified user).")
@@ -105,7 +107,7 @@ func handleSkylineCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid year range: %v", err)
 	}
 
-	return skyline.GenerateSkyline(startYear, endYear, user, full, output, artOnly)
+	return skyline.GenerateSkyline(startYear, endYear, user, label, full, output, artOnly)
 }
 
 // Browser interface matches browser.Browser functionality.

--- a/cmd/skyline/skyline.go
+++ b/cmd/skyline/skyline.go
@@ -23,7 +23,8 @@ type GitHubClientInterface interface {
 	FetchContributions(username string, year int) (*types.ContributionsResponse, error)
 }
 
-// GenerateSkyline creates a 3D model with ASCII art preview of GitHub contributions for the specified year range, or "full lifetime" of the user
+// GenerateSkyline creates a 3D model with ASCII art preview of GitHub contributions for the specified year range, or "full lifetime" of the user.
+// The 'label' parameter customizes the display name in the output; if left empty, it defaults to the targetUser.
 func GenerateSkyline(startYear, endYear int, targetUser string, label string, full bool, output string, artOnly bool) error {
 	log := logger.GetLogger()
 

--- a/cmd/skyline/skyline.go
+++ b/cmd/skyline/skyline.go
@@ -24,7 +24,7 @@ type GitHubClientInterface interface {
 }
 
 // GenerateSkyline creates a 3D model with ASCII art preview of GitHub contributions for the specified year range, or "full lifetime" of the user
-func GenerateSkyline(startYear, endYear int, targetUser string, full bool, output string, artOnly bool) error {
+func GenerateSkyline(startYear, endYear int, targetUser string, label string, full bool, output string, artOnly bool) error {
 	log := logger.GetLogger()
 
 	client, err := github.InitializeGitHubClient()
@@ -41,6 +41,9 @@ func GenerateSkyline(startYear, endYear int, targetUser string, full bool, outpu
 			return errors.New(errors.NetworkError, "failed to get authenticated user", err)
 		}
 		targetUser = username
+	}
+	if label == "" {
+		label = targetUser
 	}
 
 	if full {
@@ -61,7 +64,7 @@ func GenerateSkyline(startYear, endYear int, targetUser string, full bool, outpu
 		allContributions = append(allContributions, contributions)
 
 		// Generate ASCII art for each year
-		asciiArt, err := ascii.GenerateASCII(contributions, targetUser, year, (year == startYear) && !artOnly, !artOnly)
+		asciiArt, err := ascii.GenerateASCII(contributions, label, year, (year == startYear) && !artOnly, !artOnly)
 		if err != nil {
 			if warnErr := log.Warning("Failed to generate ASCII preview: %v", err); warnErr != nil {
 				return warnErr
@@ -96,9 +99,9 @@ func GenerateSkyline(startYear, endYear int, targetUser string, full bool, outpu
 
 		// Generate the STL file
 		if len(allContributions) == 1 {
-			return stl.GenerateSTL(allContributions[0], outputPath, targetUser, startYear)
+			return stl.GenerateSTL(allContributions[0], outputPath, label, startYear)
 		}
-		return stl.GenerateSTLRange(allContributions, outputPath, targetUser, startYear, endYear)
+		return stl.GenerateSTLRange(allContributions, outputPath, label, startYear, endYear)
 	}
 
 	return nil

--- a/cmd/skyline/skyline_test.go
+++ b/cmd/skyline/skyline_test.go
@@ -20,6 +20,7 @@ func TestGenerateSkyline(t *testing.T) {
 		startYear  int
 		endYear    int
 		targetUser string
+		label      string
 		full       bool
 		mockClient *mocks.MockGitHubClient
 		wantErr    bool
@@ -29,6 +30,7 @@ func TestGenerateSkyline(t *testing.T) {
 			startYear:  2024,
 			endYear:    2024,
 			targetUser: "testuser",
+			label:      "",
 			full:       false,
 			mockClient: &mocks.MockGitHubClient{
 				Username: "testuser",
@@ -42,6 +44,7 @@ func TestGenerateSkyline(t *testing.T) {
 			startYear:  2020,
 			endYear:    2024,
 			targetUser: "testuser",
+			label:      "",
 			full:       false,
 			mockClient: &mocks.MockGitHubClient{
 				Username: "testuser",
@@ -55,6 +58,7 @@ func TestGenerateSkyline(t *testing.T) {
 			startYear:  2008,
 			endYear:    2024,
 			targetUser: "testuser",
+			label:      "",
 			full:       true,
 			mockClient: &mocks.MockGitHubClient{
 				Username: "testuser",
@@ -72,7 +76,7 @@ func TestGenerateSkyline(t *testing.T) {
 				return github.NewClient(tt.mockClient), nil
 			}
 
-			err := GenerateSkyline(tt.startYear, tt.endYear, tt.targetUser, tt.full, "", false)
+			err := GenerateSkyline(tt.startYear, tt.endYear, tt.targetUser, tt.label, tt.full, "", false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateSkyline() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
Since long GitHub usernames can overlap with the year when creating a model, I’ve added a separate label to avoid this issue.