### PR TITLE
Add liamchampton as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # This repository is maintained by:
 
-* @chrisreddington
+* @chrisreddington @liamchampton


### PR DESCRIPTION
This pull request makes a small update to the `CODEOWNERS` file, adding @liamchampton as a maintainer alongside @chrisreddington.