### PR TITLE
Update CODEOWNERS to remove chrisreddington as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # This repository is maintained by:
 
-* @chrisreddington @liamchampton
+* @liamchampton


### PR DESCRIPTION
Removed @chrisreddington from CODEOWNERS.